### PR TITLE
Speed/Power tweaks

### DIFF
--- a/TinyRefinery/Data/CubeBlocks.sbc
+++ b/TinyRefinery/Data/CubeBlocks.sbc
@@ -27,7 +27,7 @@
       <CriticalComponent Subtype="Computer" Index="0" />
       <BlockPairName>TinyRefinery</BlockPairName>
       <EdgeType>Light</EdgeType>
-      <BuildTimeSeconds>70</BuildTimeSeconds>
+      <BuildTimeSeconds>35</BuildTimeSeconds>
       <InventoryMaxVolume>4</InventoryMaxVolume>
       <InventorySize>
         <X>2</X>
@@ -35,11 +35,11 @@
         <Z>2</Z>
       </InventorySize>
       <StandbyPowerConsumption>0.002</StandbyPowerConsumption>
-      <OperationalPowerConsumption>0.02</OperationalPowerConsumption>
+      <OperationalPowerConsumption>0.03</OperationalPowerConsumption>
       <BlueprintClasses>
         <Class>Ingots</Class>
       </BlueprintClasses>
-      <RefineSpeed>0.125</RefineSpeed>
+      <RefineSpeed>0.0000284</RefineSpeed>
       <MaterialEfficiency>1</MaterialEfficiency>
     </Definition>
 	<Definition xsi:type="MyObjectBuilder_AssemblerDefinition">
@@ -67,7 +67,7 @@
       </Components>
       <CriticalComponent Subtype="Computer" Index="0" />
       <EdgeType>Light</EdgeType>
-      <BuildTimeSeconds>80</BuildTimeSeconds>
+      <BuildTimeSeconds>40</BuildTimeSeconds>
       <InventoryMaxVolume>1</InventoryMaxVolume>
       <InventorySize>
         <X>1</X>
@@ -75,14 +75,14 @@
         <Z>1</Z>
       </InventorySize>
       <StandbyPowerConsumption>0.002</StandbyPowerConsumption>
-      <OperationalPowerConsumption>0.02</OperationalPowerConsumption>
+      <OperationalPowerConsumption>0.05</OperationalPowerConsumption>
       <BlueprintClasses>
         <Class>LargeBlocks</Class>
         <Class>SmallBlocks</Class>
         <Class>Components</Class>
         <Class>Tools</Class>
       </BlueprintClasses>
-      <RefineSpeed>0.025</RefineSpeed>
+      <RefineSpeed>0.0000625</RefineSpeed>
       <MaterialEfficiency>1</MaterialEfficiency>
     </Definition>
 	</CubeBlocks>

--- a/TinyRefinery/Data/CubeBlocks.sbc
+++ b/TinyRefinery/Data/CubeBlocks.sbc
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0"?> 
 <Definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <CubeBlocks> 
     <Definition xsi:type="MyObjectBuilder_RefineryDefinition">


### PR DESCRIPTION
Hi,

I made it so it's more survival-like, and so in order to equalise the output of a normal Assembler/Refinery you would need more Tiny Assemblers/Refineries than what you would need to fill up the same space. And it would use more power.

Also, I reduced the build time in half... just because that time is usually for a full Refinery/Assembler.

 After all, you're supposed to use those in a minimal-survival type of play, right? If you update the mod to be DX11-compatible and you leave a message for the creators of [this ship](https://steamcommunity.com/sharedfiles/filedetails/?id=566017523&searchtext=hardcore+landing+) and other tiny ships, you might have enough popularity with it that it would become a mainstream mod for hard/hardcore survival servers/plays.

Good luck with it!

Edit: By the way, are you Romanian, by any chance? I'm asking because of the `Codez!` commit title.
